### PR TITLE
Closes #1 ? - Support validation of 8 digit TFNs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ node_modules
 
 # Optional REPL history
 .node_repl_history
+
+# Intellij
+.idea

--- a/index.js
+++ b/index.js
@@ -1,13 +1,24 @@
 // see  http://www.mathgen.ch/codes/tfn.html
 
-var weights = [1, 4, 3, 7, 5, 8, 6, 9, 10];
+var nineDigitTfnWeights = [1, 4, 3, 7, 5, 8, 6, 9, 10];
+var eightDigitTfnWeights = [10, 7, 8, 4, 6, 3, 5, 1, 0];
 var multiple = 11;
 
 module.exports = function validateTFN(tfn) {
   var digits = tfn.replace(/[^\d]/g, '').split('').map(Number);
-  if (digits.length != 9)
-    return { valid: false };
+  if (digits.length == 8) {
+    return validate(digits, eightDigitTfnWeights);
+  }
 
+  if (digits.length == 9) {
+    return validate(digits, nineDigitTfnWeights);
+  }
+
+  return { valid: false };
+};
+
+
+var validate = function(digits, weights) {
   var sum = digits.reduce(function(p, v, i) { return p+v*weights[i]; }, 0);
   var suggestion = 0;
   if (sum == 0 || sum % multiple != 0) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tfn",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "validate australian tax number",
   "main": "index.js",
   "scripts": {

--- a/test/tfn.js
+++ b/test/tfn.js
@@ -1,7 +1,7 @@
 var assert = require('assert');
 var tfn = require('..');
 
-var validNumbers = [
+var validNineDigitTfns = [
  '865414088',
  '459-599-230',
  '1124-740-82',
@@ -9,16 +9,34 @@ var validNumbers = [
  '907 974 668'
 ];
 
+var validEightDigitTfns = [
+  '81 854 402',
+  '37 118 629',
+  '37 118 660',
+  '37 118 705',
+  '38 593 474',
+  '38 593 519',
+  '85 655 734',
+  '85 655 797',
+  '85 655 810',
+  '37 118 655'
+];
+
 describe('tfn', function() {
-  it('should mark valid tfn numbers as valid', function() {
-    validNumbers.forEach(function(t) {
+  it('should mark valid 9 digit tfn numbers as valid', function() {
+    validNineDigitTfns.forEach(function(t) {
       assert.deepEqual(tfn(t), { valid: true });
     });
   });
 
+  it('should mark valid 8 digit tfn numbers as valid', function() {
+    validEightDigitTfns.forEach(function(t) {
+      assert.deepEqual(tfn(t), { valid: true });
+    });
+  });
 
   it('should return suggestion that is valid tfn itself', function() {
-    validNumbers.forEach(function(t) {
+    validNineDigitTfns.forEach(function(t) {
       var validNum = t.replace(/[^\d]g/, '');
       for (var i=0; i < 0; ++i) {
         var num = validNum.slice(0,8) + i.toString();


### PR DESCRIPTION
@sidorares I've added support for 8 digit TFNs - as discussed here 
https://github.com/sidorares/tfn/issues/1

Tests pass.
- Although no coverage for the suggestion feature for 8 digit TFNs, I'm not totally sure how to get that working accurately for 8 digit TFNs, any ideas?

Open for discussion.
